### PR TITLE
Update sort.js for case-insensitive sorting of settlements

### DIFF
--- a/mod/sort/sort.js
+++ b/mod/sort/sort.js
@@ -17,7 +17,7 @@ const initialize = () => {
                 const resourceCapComparison = b.resourceCap - a.resourceCap;
                 if (resourceCapComparison !== 0) return resourceCapComparison;
                 
-                return Locale.compose(a.name).localeCompare(Locale.compose(b.name));
+                return Locale.compose(a.name).toUpperCase().localeCompare(Locale.compose(b.name).toUpperCase());
             });
         },
         set: function settlementComparator(comparator) {


### PR DESCRIPTION
Some, or at least one, default settlement name in Civ 7 starts with a lowercase letter: al-Fustāt and sorts to the bottom of the list. This should solve it.